### PR TITLE
Discordの招待リンクを修正

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@
 [Project Id Generator](https://app.kermite.org/krs/generator/) ファームウェアを新しく作る際に必要なProjectIdのジェネレータです
 
 ## 連絡先
-https://discord.gg/7662Ak2Q
+https://discord.gg/PNpEn3Z2kT
 
 Discordのサーバです。バグ報告や機能の相談などはこちらにお願いします。
 


### PR DESCRIPTION
## Description
Discordの招待リンクが期限切れで無効になっている問題を修正します。

## Types of Changes
- [ ] Suggestion
- [ ] Keyboard Firmware
- [x] Docs

## Related Issue/URL
https://discord.gg/PNpEn3Z2kT

## Comment
リンクが合っていることを確認してください🥺

※この問題は修正済みのため閉じられました。