### PR TITLE
fix: add suppress widget view for main screen

### DIFF
--- a/software/src/ui/components/window/WindowControlButton.tsx
+++ b/software/src/ui/components/window/WindowControlButton.tsx
@@ -5,10 +5,11 @@ type Props = {
   icon: string;
   onClick: () => void;
   hint?: string;
+  disabled?: boolean;
 };
 
-export const WindowControlButton: FC<Props> = ({ icon, onClick, hint }) => (
-  <div css={style} onClick={onClick} data-hint={hint}>
+export const WindowControlButton: FC<Props> = ({ icon, onClick, hint, disabled }) => (
+  <div css={style} onClick={onClick} data-hint={hint} data-disabled={disabled}>
     <i className={icon} />
   </div>
 );
@@ -25,4 +26,8 @@ const style = css`
     background: ${uiTheme.colors.clWindowButtonHoverBack};
   }
   -webkit-app-region: no-drag;
+  &[data-disabled] {
+    opacity: 0.3;
+    pointer-events: none;
+  }
 `;

--- a/software/src/ui/root/organisms/WindowControlButtonsPart.tsx
+++ b/software/src/ui/root/organisms/WindowControlButtonsPart.tsx
@@ -4,6 +4,7 @@ import {
   WindowControlButton,
   WindowRestartButton,
 } from '~/ui/components/window';
+import { profilesModel } from '~/ui/pages/editor-page/ui_bar_profileManagement/viewModels/ProfileManagementPartViewModel';
 import { makeWindowControlButtonsModel } from '~/ui/root/organisms/WindowControlButtonsPart.model';
 
 export const WindowControlButtonsPart = () => {
@@ -25,6 +26,7 @@ export const WindowControlButtonsPart = () => {
         icon="fa fa-feather-alt"
         onClick={vm.onWidgetButton}
         hint={texts.hint_titleBar_switchToWidgetView}
+        disabled={!profilesModel.isEditProfileAvailable}
       />
       <WindowControlButton
         icon="fa fa-window-minimize"


### PR DESCRIPTION
# Description
プロファイル未作成時の WidgetView ボタンを無効にします。

# Code Changes
- WindowControlButton に disabled プロパティを追加
- 上記の表示条件を追加

# ToDo
- 空のプロファイルが読み込まれたケースの対応