### PR TITLE
エンコーダを複数使用したときに動作しない不具合を修正

### DIFF
--- a/firmware/src/modules/km0/scanner/keyScanner_encoders.c
+++ b/firmware/src/modules/km0/scanner/keyScanner_encoders.c
@@ -84,14 +84,11 @@ static void encoderInstance_decodeInputOnPhaseAEdge(EncoderConfig *config, Encod
 }
 
 static uint8_t encoderInstance_pullRotationEventOne(EncoderState *state) {
-  static uint32_t tick = 0;
-  if ((++tick & 3) == 0) {
-    if (state->rots_num > 0) {
-      uint8_t rot = state->rots_buf & 1;
-      state->rots_buf >>= 1;
-      state->rots_num--;
-      return rot;
-    }
+  if (state->rots_num > 0) {
+    uint8_t rot = state->rots_buf & 1;
+    state->rots_buf >>= 1;
+    state->rots_num--;
+    return rot;
   }
   return rot_none;
 }

--- a/firmware/src/projects/dev/testbed/encoder_rp_2/config.h
+++ b/firmware/src/projects/dev/testbed/encoder_rp_2/config.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define KERMITE_FIRMWARE_ID "RcYEeq"
+#define KERMITE_KEYBOARD_NAME "encoder_rp_2"
+
+#define KM0_KEYBOARD__NUM_SCAN_SLOTS 4

--- a/firmware/src/projects/dev/testbed/encoder_rp_2/main.c
+++ b/firmware/src/projects/dev/testbed/encoder_rp_2/main.c
@@ -1,0 +1,27 @@
+#include "config.h"
+#include "km0/device/boardIoImpl.h"
+#include "km0/device/debugUart.h"
+#include "km0/device/digitalIo.h"
+#include "km0/kernel/keyboardMain.h"
+#include "km0/scanner/keyScanner_directWired.h"
+#include "km0/scanner/keyScanner_encoders.h"
+#include "km0/wrapper/generalKeyboard.h"
+
+#define NumEncoders 2
+#define NumScanSlots (NumEncoders * 2)
+
+static EncoderConfig encoderConfigs[NumEncoders] = {
+  { .pinA = GP15, .pinB = GP26, .scanIndexBase = 0 },
+  { .pinA = GP27, .pinB = GP28, .scanIndexBase = 2 },
+
+};
+
+int main() {
+  // debugUart_initialize(38400);
+  boardIoImpl_setupLeds_rp2040zero();
+  keyScanner_encoders_initialize(NumEncoders, encoderConfigs);
+  keyboardMain_useKeyScanner(keyScanner_directWired_update);
+  keyboardMain_useKeyScanner(keyScanner_encoders_update);
+  generalKeyboard_start();
+  return 0;
+}

--- a/firmware/src/projects/dev/testbed/encoder_rp_2/main.c
+++ b/firmware/src/projects/dev/testbed/encoder_rp_2/main.c
@@ -11,16 +11,14 @@
 #define NumScanSlots (NumEncoders * 2)
 
 static EncoderConfig encoderConfigs[NumEncoders] = {
-  { .pinA = GP15, .pinB = GP26, .scanIndexBase = 0 },
-  { .pinA = GP27, .pinB = GP28, .scanIndexBase = 2 },
-
+  { .pinA = GP2, .pinB = GP3, .scanIndexBase = 0 },
+  { .pinA = GP4, .pinB = GP5, .scanIndexBase = 2 },
 };
 
 int main() {
   // debugUart_initialize(38400);
-  boardIoImpl_setupLeds_rp2040zero();
+  boardIoImpl_setupLeds_kb2040();
   keyScanner_encoders_initialize(NumEncoders, encoderConfigs);
-  keyboardMain_useKeyScanner(keyScanner_directWired_update);
   keyboardMain_useKeyScanner(keyScanner_encoders_update);
   generalKeyboard_start();
   return 0;

--- a/firmware/src/projects/dev/testbed/encoder_rp_2/rules.mk
+++ b/firmware/src/projects/dev/testbed/encoder_rp_2/rules.mk
@@ -1,0 +1,28 @@
+TARGET_MCU = rp2040
+
+MODULE_SRCS += km0/base/utils.c
+MODULE_SRCS += km0/device/rp2040/system.c
+MODULE_SRCS += km0/device/rp2040/digitalIo.c
+MODULE_SRCS += km0/device/rp2040/usbIoCore.c
+MODULE_SRCS += km0/device/rp2040/dataMemory.c
+MODULE_SRCS += km0/device/rp2040/debugUart.c
+MODULE_SRCS += km0/device/boardIo.c
+MODULE_SRCS += km0/device/rp2040/boardIoImpl.c
+MODULE_SRCS += km0/device/rp2040/boardIoImpl_rgbLed.c
+MODULE_PIOASM_SRCS += km0/device/rp2040/neoPixelCore.pio
+MODULE_SRCS += km0/device/rp2040/neoPixelCore.c
+MODULE_SRCS += km0/device/rp2040/pinObserver.c
+MODULE_SRCS += km0/kernel/dataStorage.c
+MODULE_SRCS += km0/kernel/configManager.c
+MODULE_SRCS += km0/kernel/firmwareMetadata.c
+MODULE_SRCS += km0/kernel/keyMappingDataValidator.c
+MODULE_SRCS += km0/kernel/configuratorServant.c
+MODULE_SRCS += km0/kernel/keyCodeTranslator.c
+MODULE_SRCS += km0/kernel/keyActionRemapper.c
+MODULE_SRCS += km0/kernel/keyboardCoreLogic.c
+MODULE_SRCS += km0/kernel/keyboardMain.c
+MODULE_SRCS += km0/scanner/keyScanner_directWired.c
+MODULE_SRCS += km0/scanner/keyScanner_encoders.c
+MODULE_SRCS += km0/wrapper/generalKeyboard.c
+
+PROJECT_SRCS += main.c


### PR DESCRIPTION
エンコーダを複数使ったときに、1個目のエンコーダが反応しないバグがあり、これを修正しました。
パルスの読み出しを遅延させる処理に問題があったため、この遅延処理を削除しました。