### PR TITLE
分割キーボードのスレーブ側でエンコーダの初期化をスキップ

### DIFF
--- a/firmware/src/modules/km0/wrapper/splitKeyboard.h
+++ b/firmware/src/modules/km0/wrapper/splitKeyboard.h
@@ -3,5 +3,5 @@
 #include "km0/types.h"
 
 void splitKeyboard_setNumScanSlots(uint8_t numScanSlotsLeft, uint8_t numScanSlotsRight);
-void splitKeyboard_setBoardConfigCallback(void (*callback)(int8_t side));
+void splitKeyboard_setBoardConfigCallback(void (*callback)(int8_t side, bool isMaster));
 void splitKeyboard_start();

--- a/firmware/src/projects/standard/common/main_split.c
+++ b/firmware/src/projects/standard/common/main_split.c
@@ -75,7 +75,7 @@ KermiteKeyboardDefinitionData defs = {
 static EncoderConfig encoderConfigs[1] = { { .pinA = 0, .pinB = 0, .scanIndexBase = 0 } };
 static EncoderConfig encoderConfigsR[1] = { { .pinA = 0, .pinB = 0, .scanIndexBase = 0 } };
 
-static void setupBoard(int8_t side) {
+static void setupBoard(int8_t side, bool isMaster) {
 
   uint8_t *pins = defs.keyScannerPins;
 
@@ -139,8 +139,12 @@ static void setupBoard(int8_t side) {
       config->pinA = encoderPins[0];
       config->pinB = encoderPins[1];
       config->scanIndexBase = scanIndexBaseL;
-      keyScanner_encoders_initialize(1, encoderConfigs);
-      keyboardMain_useKeyScanner(keyScanner_encoders_update);
+      if (isMaster) {
+        keyScanner_encoders_initialize(1, encoderConfigs);
+        keyboardMain_useKeyScanner(keyScanner_encoders_update);
+      } else {
+        //encoders are not supported in slave side
+      }
       scanIndexBaseL += 2;
     }
     if (side == 1 && defs.numEncoderRight == 1) {
@@ -148,8 +152,12 @@ static void setupBoard(int8_t side) {
       config->pinA = encoderPinsR[0];
       config->pinB = encoderPinsR[1];
       config->scanIndexBase = scanIndexBaseR;
-      keyScanner_encoders_initialize(1, encoderConfigs);
-      keyboardMain_useKeyScanner(keyScanner_encoders_update);
+      if (isMaster) {
+        keyScanner_encoders_initialize(1, encoderConfigs);
+        keyboardMain_useKeyScanner(keyScanner_encoders_update);
+      } else {
+        //encoders are not supported in slave side
+      }
       scanIndexBaseR += 2;
     }
   }


### PR DESCRIPTION
分割キーボードのスレーブ側で、エンコーダのピン変化割り込みが左右間通信のピン変化割り込みのハンドラを上書きしてしまい左右間の通信に応答できなくなってしまう問題があります。これを回避するため、スレーブ側でエンコーダの初期化をスキップするようにしました。
分割キーボードの構成で、仕様上スレーブ側のエンコーダは動作をサポートしないものとします。このPRでは、スレーブ側のエンコーダを除いてそれ以外の機能が動作するように修正しました。